### PR TITLE
feat(project): Show related project link on project cards

### DIFF
--- a/src/components/Project/Project.jsx
+++ b/src/components/Project/Project.jsx
@@ -37,6 +37,11 @@ const Project = ({project}) => {
                 </div>
             </div>
             <p className={style.description}>{project.description || <span>There is no description yet</span>}</p>
+            {project.related && (
+                <p className={style.related}>
+                    Part of: <a href={project.related.link} target="_blank">{project.related.name}</a>
+                </p>
+            )}
             <a href={project.link} target="_blank">View on GitHub</a>
         </div>
     );

--- a/src/components/Project/Project.module.css
+++ b/src/components/Project/Project.module.css
@@ -64,6 +64,12 @@
     box-sizing: border-box;
     overflow-wrap: break-word;
 }
+.related {
+    font-size: 0.9em;
+    color: #718096;
+    margin: 4px 0;
+}
+
 .project a {
     color: #2b6cb0;
     text-decoration: none;

--- a/src/data.json
+++ b/src/data.json
@@ -88,6 +88,7 @@
         "name": "Social Network Frontend",
         "description": "React 19 SPA for the Social Network backend. Handles login, registration, posting, following and real-time chat — STOMP over WebSocket powers messaging and a separate presence channel tracks who's online. Auth state is managed through a React context with protected routes and Sentry captures client-side errors.",
         "tags": ["ReactJS", "WebSocket", "STOMP", "Axios", "React Router", "Sentry"],
+        "related": { "name": "Social Network", "link": "https://github.com/knetsov91/social-network" },
         "link": "https://github.com/knetsov91/social-network-react"
     }
 ]


### PR DESCRIPTION
## Summary
- Add a **related** field to project entries in data.json; when present render a styled "Part of: <name>" link on the card pointing to that project's GitHub repo
- Set the Social Network Frontend entry's **related** field to point at its backend repo