### PR TITLE
feat(project): Add expandable demo gif section to project cards

### DIFF
--- a/src/components/Project/Project.jsx
+++ b/src/components/Project/Project.jsx
@@ -59,13 +59,16 @@ const Project = ({project}) => {
             </div>
             {demoGifs.length > 0 && showDemo && (
                 <div className={style.demoSection}>
-                    <img src={demoGifs[activeGif]} alt={`${project.name} demo`} className={style.demoGif} />
+                    <img src={demoGifs[activeGif].url} alt={`${project.name} demo`} className={style.demoGif} />
+                    {demoGifs[activeGif].description && (
+                        <p className={style.demoDescription}>{demoGifs[activeGif].description}</p>
+                    )}
                     {demoGifs.length > 1 && (
                         <div className={style.demoTabs}>
                             {demoGifs.map((gif, i) => (
                                 <button
                                     type="button"
-                                    key={gif}
+                                    key={gif.url}
                                     className={`${style.demoTab} ${i === activeGif ? style.demoTabActive : ''}`}
                                     onClick={() => setActiveGif(i)}
                                 >

--- a/src/components/Project/Project.jsx
+++ b/src/components/Project/Project.jsx
@@ -6,7 +6,10 @@ import { fetchRepoData, generateRepoUrl } from '../../utils/util';
 const Project = ({project}) => {
     const [createdAt, setCreatedAt] = useState('N/A')
     const [updatedAt, setUpdatedAt] = useState('N/A')
+    const [showDemo, setShowDemo] = useState(false);
+    const [activeGif, setActiveGif] = useState(0);
     const fetchUrl = generateRepoUrl(project.link);
+    const demoGifs = project.demoGifs || [];
 
     useEffect(() => {
        fetchRepoData(fetchUrl)
@@ -42,7 +45,37 @@ const Project = ({project}) => {
                     Part of: <a href={project.related.link} target="_blank">{project.related.name}</a>
                 </p>
             )}
-            <a href={project.link} target="_blank">View on GitHub</a>
+            <div className={style.links}>
+                <a href={project.link} target="_blank">View on GitHub</a>
+                {demoGifs.length > 0 && (
+                    <button
+                        type="button"
+                        className={style.demoToggle}
+                        onClick={() => { setShowDemo((prev) => !prev); setActiveGif(0); }}
+                    >
+                        {showDemo ? 'Hide demo' : 'Demo'}
+                    </button>
+                )}
+            </div>
+            {demoGifs.length > 0 && showDemo && (
+                <div className={style.demoSection}>
+                    <img src={demoGifs[activeGif]} alt={`${project.name} demo`} className={style.demoGif} />
+                    {demoGifs.length > 1 && (
+                        <div className={style.demoTabs}>
+                            {demoGifs.map((gif, i) => (
+                                <button
+                                    type="button"
+                                    key={gif}
+                                    className={`${style.demoTab} ${i === activeGif ? style.demoTabActive : ''}`}
+                                    onClick={() => setActiveGif(i)}
+                                >
+                                    {i + 1}
+                                </button>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/Project/Project.module.css
+++ b/src/components/Project/Project.module.css
@@ -92,10 +92,22 @@
     font-size: larger;
     font-weight: bold;
     cursor: pointer;
+    position: relative;
 }
 
-.demoToggle:hover {
-    text-decoration: underline;
+.demoToggle::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 0;
+    height: 2px;
+    background-color: currentColor;
+    transition: width 0.3s ease;
+}
+
+.demoToggle:hover::after {
+    width: 100%;
 }
 
 .demoSection {

--- a/src/components/Project/Project.module.css
+++ b/src/components/Project/Project.module.css
@@ -112,6 +112,13 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
+.demoDescription {
+    font-size: 0.9em;
+    color: #718096;
+    text-align: center;
+    margin: 8px 0 0;
+}
+
 .demoTabs {
     display: flex;
     gap: 6px;

--- a/src/components/Project/Project.module.css
+++ b/src/components/Project/Project.module.css
@@ -77,6 +77,63 @@
     font-weight: bold;
 }
 
+.links {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.demoToggle {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: #2b6cb0;
+    font-size: larger;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.demoToggle:hover {
+    text-decoration: underline;
+}
+
+.demoSection {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    margin-top: 12px;
+}
+
+.demoGif {
+    max-width: 100%;
+    border-radius: 6px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.demoTabs {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+}
+
+.demoTab {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    border: 1px solid #2b6cb0;
+    background-color: #fff;
+    color: #2b6cb0;
+    font-size: 0.85em;
+    cursor: pointer;
+}
+
+.demoTabActive {
+    background-color: #2b6cb0;
+    color: #fff;
+}
+
 .project:hover {
     background-color: #ddb8b8;
 }

--- a/src/data.json
+++ b/src/data.json
@@ -9,6 +9,7 @@
          "MySQL", "PostgreSQL", "MongoDB", "Docker", "JWT",
          "HashiCorp Vault", "Sentry", "OpenTelemetry", "Jaeger",
          "Prometheus", "Grafana", "OpenFeign", "Resilience4j", "GitHub Actions"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/social-network"
     },
     {
@@ -19,6 +20,7 @@
          "Kafka", "PostgreSQL", "MongoDB",
          "Docker", "Traefik", "Consul",
          "Prometheus", "Grafana", "Elasticsearch", "Kibana"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/e-shop"
     },
     {
@@ -26,6 +28,7 @@
         "name": "Multimodal Search",
         "description": "The project follows a 3-tier architecture — Jinja2 templates on the presentation layer, FastAPI with a services layer handling business logic and PostgreSQL/Milvus/MinIO as the data tier. The backend is organized around an MVC pattern where endpoints act as controllers, SQLAlchemy models and Pydantic schemas handle the model layer and Jinja2 templates serve as views. Built a two-stage multimodal retrieval system in Python combining dense vector search with vision-language reranking. Each stage depends on an abstract interface — BaseRetrieval and BaseReranker — so the current models (CLIP for retrieval and Qwen3-VL-4B-Instruct for reranking) can be swapped out without changing the pipeline. The first stage uses CLIP model to encode text and image queries, fuses the similarity scores and retrieves top candidates from Milvus a vector database optimized for similarity search. The second stage runs Qwen3-VL-4B-Instruct with quantization to visually score each result against the original query. The whole system is containerized with Docker Compose with NVIDIA GPU support, uses FastAPI as the web framework, PostgreSQL for relational data and MinIO as S3-compatible object storage for images.",
         "tags": ["Python", "FastAPI", "PostgreSQL", "Docker", "GPU", "MVC", "Vector Search", "Multimodal", "Milvus", "MinIO", "AI"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/multimodal_search"
     },
     {
@@ -35,6 +38,7 @@
         "tags": ["Java", "Spring Boot", "Hibernate",
          "Gradle", "OpenAPI", "REST",
          "GitHub Actions", "JUnit", "PostgreSQL"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/restaurant"
     },
      {
@@ -44,6 +48,7 @@
         "tags": ["Python", "FastAPI", "PostgreSQL",
          "ReactJS", "SQLAlchemy", "JWT",
          "GitHub Actions", "Docker"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/fastapi-react-postgresql"
     },
     {
@@ -54,6 +59,7 @@
          "Gradle", "MySQL", "Docker",
          "Kubernetes", "GitHub Actions",
          "AWS", "IaC", "CDK", "SonarQube", "JUnit"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/project-management"
     },
     {
@@ -63,6 +69,7 @@
         "tags": ["Python", "FastAPI", "Pytest",
          "REST", "Docker", "PostgreSQL",
          "SQLAlchemy", "GitHub Actions", "ReactJS"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/python-react-NER-project"
     },
     {
@@ -73,6 +80,7 @@
          "JWT", "Angular", "MySQL",
          "Docker", "Azure", "Terraform",
          "IaC", "GitHub Actions"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/angular-rest"
     },
     {
@@ -81,6 +89,7 @@
         "description": "Infrastructure as Code project that provisions Azure cloud resources using Terraform for deploying a containerized application. Automated via GitHub Actions for repeatable, version-controlled deployments.",
         "tags": ["Azure", "GitHub Actions",
          "Terraform", "IaC"],
+        "demoGifs": [],
         "link": "https://github.com/knetsov91/azure-terraform"
     },
     {
@@ -89,6 +98,7 @@
         "description": "React 19 SPA for the Social Network backend. Handles login, registration, posting, following and real-time chat — STOMP over WebSocket powers messaging and a separate presence channel tracks who's online. Auth state is managed through a React context with protected routes and Sentry captures client-side errors.",
         "tags": ["ReactJS", "WebSocket", "STOMP", "Axios", "React Router", "Sentry"],
         "related": { "name": "Social Network", "link": "https://github.com/knetsov91/social-network" },
+        "demoGifs": ["https://github.com/knetsov91/social-network-react/raw/dev/chats.gif"],
         "link": "https://github.com/knetsov91/social-network-react"
     }
 ]

--- a/src/data.json
+++ b/src/data.json
@@ -98,7 +98,12 @@
         "description": "React 19 SPA for the Social Network backend. Handles login, registration, posting, following and real-time chat — STOMP over WebSocket powers messaging and a separate presence channel tracks who's online. Auth state is managed through a React context with protected routes and Sentry captures client-side errors.",
         "tags": ["ReactJS", "WebSocket", "STOMP", "Axios", "React Router", "Sentry"],
         "related": { "name": "Social Network", "link": "https://github.com/knetsov91/social-network" },
-        "demoGifs": ["https://github.com/knetsov91/social-network-react/raw/dev/chats.gif"],
+        "demoGifs": [
+            {
+                "url": "https://github.com/knetsov91/social-network-react/raw/dev/chats.gif",
+                "description": "Register and login flow followed by real-time chat powered by WebSocket."
+            }
+        ],
         "link": "https://github.com/knetsov91/social-network-react"
     }
 ]


### PR DESCRIPTION
- Add an expandable demo gif section to project cards, toggled by a "Demo" button next to "View on GitHub"
- Support multiple gifs per project with numbered tab buttons
- Add a description field for each gif rendered under the image
- Give the demo toggle the same animated underline hover effect as the GitHub link