### PR TITLE
feat(projects): Add filter by demo availability

### DIFF
--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -10,12 +10,16 @@ const Projects = () => {
     const [projects, setProjects] = useState([]);
     const [page, setPage] = useState(1);
     const [filter, setFilter] = useState("all");
+    const [demoOnly, setDemoOnly] = useState(false);
 
     useEffect(() => {
         setProjects(data);
     }, []);
 
-    const filtered = filter === "all" ? projects : projects.filter(p => p.type === filter);
+    const matchesType = (p, f) => f === "all" || p.type === f;
+    const hasDemo = (p) => p.demoGifs && p.demoGifs.length > 0;
+
+    const filtered = projects.filter(p => matchesType(p, filter) && (!demoOnly || hasDemo(p)));
     const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
     const visible = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
@@ -24,7 +28,13 @@ const Projects = () => {
         setPage(1);
     };
 
+    const handleDemoFilter = () => {
+        setDemoOnly(d => !d);
+        setPage(1);
+    };
+
     const countFor = (f) => f === "all" ? projects.length : projects.filter(p => p.type === f).length;
+    const demoCount = projects.filter(hasDemo).length;
 
     return (
         <>
@@ -38,6 +48,14 @@ const Projects = () => {
                         {f} ({countFor(f)})
                     </button>
                 ))}
+            </div>
+            <div className={style.demoFilters}>
+                <button
+                    onClick={handleDemoFilter}
+                    className={demoOnly ? style.active : style.demoButton}
+                >
+                    has demo ({demoCount})
+                </button>
             </div>
             {visible.map(p => <Project project={p} key={p.id} />)}
             {totalPages > 1 && (

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -61,12 +61,12 @@ const Projects = () => {
                     ))}
                 </div>
                 <div className={style.demoFilters}>
-                    <span className={style.filterLabel}>Demo:</span>
+                    <span className={style.filterLabel}>Has Demo:</span>
                     <button
                         onClick={handleDemoFilter}
-                        className={demoOnly ? style.active : style.demoButton}
+                        className={demoOnly ? `${style.active} ${style.demoButtonActive}` : style.demoButton}
                     >
-                        has demo ({demoCount})
+                        Yes ({demoCount})
                     </button>
                 </div>
             </div>

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -38,24 +38,29 @@ const Projects = () => {
 
     return (
         <>
-            <div className={style.filters}>
-                {FILTERS.map(f => (
+            <div className={style.filterSection}>
+                <p className={style.filterSectionLabel}>Filters</p>
+                <div className={style.filters}>
+                    <span className={style.filterLabel}>Type:</span>
+                    {FILTERS.map(f => (
+                        <button
+                            key={f}
+                            onClick={() => handleFilter(f)}
+                            className={filter === f ? style.active : ""}
+                        >
+                            {f} ({countFor(f)})
+                        </button>
+                    ))}
+                </div>
+                <div className={style.demoFilters}>
+                    <span className={style.filterLabel}>Demo:</span>
                     <button
-                        key={f}
-                        onClick={() => handleFilter(f)}
-                        className={filter === f ? style.active : ""}
+                        onClick={handleDemoFilter}
+                        className={demoOnly ? style.active : style.demoButton}
                     >
-                        {f} ({countFor(f)})
+                        has demo ({demoCount})
                     </button>
-                ))}
-            </div>
-            <div className={style.demoFilters}>
-                <button
-                    onClick={handleDemoFilter}
-                    className={demoOnly ? style.active : style.demoButton}
-                >
-                    has demo ({demoCount})
-                </button>
+                </div>
             </div>
             {visible.map(p => <Project project={p} key={p.id} />)}
             {totalPages > 1 && (

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -25,16 +25,23 @@ const Projects = () => {
 
     const handleFilter = (f) => {
         setFilter(f);
+        if (f === "all") setDemoOnly(false);
         setPage(1);
     };
 
     const handleDemoFilter = () => {
-        setDemoOnly(d => !d);
+        setDemoOnly(d => {
+            const next = !d;
+            if (next) setFilter("all");
+            return next;
+        });
         setPage(1);
     };
 
-    const countFor = (f) => f === "all" ? projects.length : projects.filter(p => p.type === f).length;
-    const demoCount = projects.filter(hasDemo).length;
+    const countFor = (f) => f === "all"
+        ? projects.length
+        : projects.filter(p => matchesType(p, f) && (!demoOnly || hasDemo(p))).length;
+    const demoCount = projects.filter(p => matchesType(p, filter) && hasDemo(p)).length;
 
     return (
         <>
@@ -46,7 +53,7 @@ const Projects = () => {
                         <button
                             key={f}
                             onClick={() => handleFilter(f)}
-                            className={filter === f ? style.active : ""}
+                            className={filter === f && !demoOnly ? style.active : ""}
                         >
                             {f} ({countFor(f)})
                         </button>

--- a/src/components/Projects/Projects.jsx
+++ b/src/components/Projects/Projects.jsx
@@ -53,6 +53,7 @@ const Projects = () => {
                         <button
                             key={f}
                             onClick={() => handleFilter(f)}
+                            disabled={demoOnly && countFor(f) === 0}
                             className={filter === f && !demoOnly ? style.active : ""}
                         >
                             {f} ({countFor(f)})

--- a/src/components/Projects/Projects.module.css
+++ b/src/components/Projects/Projects.module.css
@@ -43,8 +43,13 @@
     cursor: pointer;
 }
 
-.filters button:hover {
+.filters button:hover:not(:disabled) {
     background-color: #bee3f8;
+}
+
+.filters button:disabled {
+    opacity: 0.4;
+    cursor: default;
 }
 
 .demoFilters {

--- a/src/components/Projects/Projects.module.css
+++ b/src/components/Projects/Projects.module.css
@@ -76,6 +76,12 @@
     background-color: #ebf8ff;
 }
 
+.demoButtonActive {
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 0.9em;
+}
+
 .pagination {
     display: flex;
     justify-content: center;

--- a/src/components/Projects/Projects.module.css
+++ b/src/components/Projects/Projects.module.css
@@ -1,9 +1,35 @@
+.filterSection {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    padding: 16px;
+    margin: 20px 0;
+}
+
+.filterSectionLabel {
+    margin: 0 0 12px;
+    font-size: 0.85em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #718096;
+    text-align: center;
+}
+
+.filterLabel {
+    display: flex;
+    align-items: center;
+    font-size: 0.9em;
+    font-weight: 600;
+    color: #4a5568;
+}
+
 .filters {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
     gap: 8px;
-    margin: 20px 0;
+    margin: 0 0 12px;
 }
 
 .filters button {
@@ -25,8 +51,9 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    align-items: center;
     gap: 8px;
-    margin: 0 0 20px;
+    margin: 0;
 }
 
 .demoButton {

--- a/src/components/Projects/Projects.module.css
+++ b/src/components/Projects/Projects.module.css
@@ -21,6 +21,29 @@
     background-color: #bee3f8;
 }
 
+.demoFilters {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 8px;
+    margin: 0 0 20px;
+}
+
+.demoButton {
+    padding: 8px 14px;
+    border: 1px solid #2b6cb0;
+    border-radius: 4px;
+    background-color: transparent;
+    color: #2b6cb0;
+    font-size: 1em;
+    text-transform: capitalize;
+    cursor: pointer;
+}
+
+.demoButton:hover {
+    background-color: #ebf8ff;
+}
+
 .pagination {
     display: flex;
     justify-content: center;

--- a/src/components/Projects/Projects.module.css
+++ b/src/components/Projects/Projects.module.css
@@ -26,7 +26,7 @@
 .filters {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 8px;
     margin: 0 0 12px;
@@ -50,7 +50,7 @@
 .demoFilters {
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 8px;
     margin: 0;


### PR DESCRIPTION
## Summary
- Add a "Has Demo" filter that combines with the existing type filter
- Selecting "all" clears the demo filter and selecting the demo filter clears any active type selection
- Type filters with zero results are disabled while the demo filter is active