### PR TITLE
feat(projects): Show demo example count next to demo toggle

### DIFF
--- a/src/components/Project/Project.jsx
+++ b/src/components/Project/Project.jsx
@@ -53,7 +53,9 @@ const Project = ({project}) => {
                         className={style.demoToggle}
                         onClick={() => { setShowDemo((prev) => !prev); setActiveGif(0); }}
                     >
-                        {showDemo ? 'Hide demo' : 'Demo'}
+                        {showDemo
+                            ? 'Hide demo'
+                            : `Demo | ${demoGifs.length} example${demoGifs.length > 1 ? 's' : ''}`}
                     </button>
                 )}
             </div>


### PR DESCRIPTION
## Summary
- Show the number of demo examples next to the demo toggle button (e.g. "Demo | 3 examples")